### PR TITLE
refactor: remove .profile from setup

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -25,8 +25,7 @@ var questions = []*survey.Question{
 // Create an up.json file for the user.
 func Create() error {
 	var in struct {
-		Name    string `json:"name"`
-		Profile string `json:"profile"`
+		Name string `json:"name"`
 	}
 
 	if err := survey.Ask(questions, &in); err != nil {


### PR DESCRIPTION
ends up being empty, meant to remove this

Open an issue and discuss changes before spending time on them, unless the change is trivial or an issue already exists.

Use "VERB some thing here. Closes #n" to close the relevant issue, where VERB is one of:

  - add
  - remove
  - change
  - refactor

If the change is documentation related prefix with "docs: ", as these are filtered from the changelog.

  docs: add ~/.aws/config

Run `dep ensure` if you introduce any new `import`'s so they're included in the ./vendor dir.
