### PR TITLE
fix: add a ! in front of build.gradle (#518)

### DIFF
--- a/internal/zip/zip.go
+++ b/internal/zip/zip.go
@@ -44,7 +44,7 @@ func Build(dir string) (io.ReadCloser, *archive.Stats, error) {
 		gitignore,
 		strings.NewReader("\n!node_modules/**\n!.pypath/**\n"),
 		upignore,
-		strings.NewReader("\n!main\n!server\n!_proxy.js\n!byline.js\n!up.json\n!pom.xml\nbuild.gradle\n"))
+		strings.NewReader("\n!main\n!server\n!_proxy.js\n!byline.js\n!up.json\n!pom.xml\n!build.gradle\n"))
 
 	filter, err := archive.FilterPatterns(r)
 	if err != nil {


### PR DESCRIPTION
Open an issue and discuss changes before spending time on them, unless the change is trivial or an issue already exists.

Use "VERB some thing here. Closes #n" to close the relevant issue, where VERB is one of:

  - add
  - remove
  - change
  - refactor

If the change is documentation related prefix with "docs: ", as these are filtered from the changelog.

  docs: add ~/.aws/config

Run `dep ensure` if you introduce any new `import`'s so they're included in the ./vendor dir.
